### PR TITLE
Allow user to use their own id for the modal

### DIFF
--- a/src/van11y-accessible-modal-window-aria.es6.js
+++ b/src/van11y-accessible-modal-window-aria.es6.js
@@ -245,7 +245,9 @@
           let wrapperBody = findById(WRAPPER_PAGE_JS);
           let body = doc.querySelector('body');
 
+        if(! modal_node.getAttribute('id')){
           modal_node.setAttribute('id', MODAL_ID_PREFIX + iLisible);
+        }
           modal_node.setAttribute(ATTR_HASPOPUP, ATTR_HASPOPUP_VALUE);
 
           if (wrapperBody === null || wrapperBody.length === 0) {


### PR DESCRIPTION
Allow users to set their own id on the button that controls the modal. This is useful for pages that have multiple modals that need to be controlled by ids (e.g. loading content with ajax content different for each button).